### PR TITLE
fix deprecated compress.warnings option

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -48,9 +48,7 @@ const webpackConfig = merge(baseWebpackConfig, {
     }),
     new UglifyJsPlugin({
       uglifyOptions: {
-        compress: {
-          warnings: false
-        }
+        warnings: false
       },
       sourceMap: config.build.productionSourceMap,
       parallel: true


### PR DESCRIPTION
option is deprecated and causes build failure:
https://github.com/mishoo/UglifyJS2/issues/3394